### PR TITLE
updating kernel.php to enable make:seeder command

### DIFF
--- a/src/Roots/Acorn/Console/Kernel.php
+++ b/src/Roots/Acorn/Console/Kernel.php
@@ -18,6 +18,7 @@ class Kernel extends FoundationConsoleKernel
         \Illuminate\Cache\Console\ForgetCommand::class,
         \Illuminate\Database\Console\DbCommand::class,
         \Illuminate\Database\Console\Seeds\SeedCommand::class,
+        \Illuminate\Database\Console\Seeds\SeederMakeCommand::class,
         \Illuminate\Database\Console\WipeCommand::class,
         \Illuminate\Foundation\Console\ClearCompiledCommand::class,
         \Illuminate\Foundation\Console\ComponentMakeCommand::class,


### PR DESCRIPTION
`wp acorn make:seeder UserTest` does not work atm. This change enables the command.